### PR TITLE
Fix URL in setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 # Created by https://www.gitignore.io/api/django
 # Edit at https://www.gitignore.io/?templates=django
 
+env/
+
 ### Django ###
 *.log
 *.pot

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import find_packages, setup, Command
 # Package meta-data.
 NAME = 'inertia-django'
 DESCRIPTION = 'inertia connector for django'
-URL = 'https://github.com/zodman/django-inertia'
+URL = 'https://github.com/zodman/inertia-django'
 EMAIL = 'zodman@gmail.com'
 AUTHOR = 'Andres vargas'
 REQUIRES_PYTHON = '>=3.7.0'


### PR DESCRIPTION
Hey I noticed the URL in the setup.py file points to a URL which results in a 404 not found. I have updated it in this PR.

Add env/ to .gitignore
Fix repo URL in setup.py to point to https://github.com/zodman/inertia-django