### PR TITLE
Update status code to 303 when redirects from put,patch,delete

### DIFF
--- a/inertia/middleware.py
+++ b/inertia/middleware.py
@@ -1,4 +1,4 @@
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseRedirect
 from .share import share
 from .version import asset_version
 
@@ -20,10 +20,17 @@ class InertiaMiddleware:
                 response = HttpResponse(status=409)
                 response["X-Inertia-Location"] = request.get_full_path_info()
                 return response
+
         share(request, "flash", {
             'success': request.session.get("success", False),
             'error': request.session.get("error", False)
         })
         share(request, 'errors', request.session.get("errors", {}))
         response = self.get_response(request)
+
+        # manage PUT, PATCH, DELETE redirections
+        if request.method in ["PUT", "PATCH", "DELETE"] and \
+            isinstance(response, HttpResponseRedirect) and \
+            response.status_code == 302:
+            response.status_code = 303
         return response

--- a/inertia/share.py
+++ b/inertia/share.py
@@ -14,7 +14,7 @@ def share_flash(request, success=False, error=False, errors=False):
         request.session["error"] = error
 
     if errors:
-        request.session["error"] = errors
+        request.session["errors"] = errors
 
     # log.info(("share", success, error, errors))
     share(request, "flash",{'success':success,'error':error})

--- a/test.py
+++ b/test.py
@@ -4,7 +4,7 @@ from unittest import mock
 import django
 from django.conf import settings
 from django.test import RequestFactory
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseRedirect
 import os
 
 settings.configure(
@@ -66,3 +66,19 @@ class TestInertia(TestCase):
         self.set_session(request)
         response = InertiaMiddleware(view)(request)
         self.assertTrue(response.status_code == 200, response.status_code)
+
+    def test_redirect_303_for_put_patch_delete_requests(self):
+        request = RequestFactory().put("/users/1")
+        self.set_session(request)
+        response = InertiaMiddleware(lambda x: HttpResponseRedirect(redirect_to="/users"))(request)
+        self.assertTrue(response.status_code==303, response.status_code)
+
+        request = RequestFactory().patch("/users/1")
+        self.set_session(request)
+        response = InertiaMiddleware(lambda x: HttpResponseRedirect(redirect_to="/users"))(request)
+        self.assertTrue(response.status_code==303, response.status_code)
+
+        request = RequestFactory().delete("/users/1")
+        self.set_session(request)
+        response = InertiaMiddleware(lambda x: HttpResponseRedirect(redirect_to="/users"))(request)
+        self.assertTrue(response.status_code==303, response.status_code)


### PR DESCRIPTION
I added one missing feature of the adapter, when using PUT, PATCH or DELETE methods. It is described here https://inertiajs.com/redirects in `303 response code` part. 

Thanks for creating the Django adapter 👍  !

I will add missing tests for this new case.


